### PR TITLE
[WIP] Added CORES_TO_USE local storage var to control cores for mining

### DIFF
--- a/src/api/GameManager.ts
+++ b/src/api/GameManager.ts
@@ -18,9 +18,9 @@ import {
 } from '../_types/global/GlobalTypes';
 import LocalStorageManager from './LocalStorageManager';
 import {
-  LOCATION_ID_UB,
   MAX_CHUNK_SIZE,
-  DERIVED_CHUNK_SIZE, MIN_CHUNK_SIZE
+  MIN_CHUNK_SIZE,
+  DERIVED_CHUNK_SIZE
 } from '../utils/constants';
 import mimcHash from '../miner/mimc';
 import ContractsAPI from './ContractsAPI';

--- a/src/api/GameManager.ts
+++ b/src/api/GameManager.ts
@@ -20,7 +20,7 @@ import LocalStorageManager from './LocalStorageManager';
 import {
   LOCATION_ID_UB,
   MAX_CHUNK_SIZE,
-  DERIVED_CHUNK_SIZE
+  DERIVED_CHUNK_SIZE, MIN_CHUNK_SIZE
 } from '../utils/constants';
 import mimcHash from '../miner/mimc';
 import ContractsAPI from './ContractsAPI';

--- a/src/api/GameManager.ts
+++ b/src/api/GameManager.ts
@@ -63,14 +63,11 @@ export enum GameManagerEvent {
 }
 import TerminalEmitter, { TerminalTextStyle } from '../utils/TerminalEmitter';
 import { getAllTwitters, verifyTwitterHandle } from './UtilityServerAPI';
-<<<<<<< HEAD
 import EthereumAccountManager from './EthereumAccountManager';
 import { getRandomActionId } from '../utils/Utils';
 import NotificationManager from '../utils/NotificationManager';
 import { deriveChunkSize, parseCoresInput } from '../utils/cores';
-=======
 import { CORES_TO_USE } from '../utils/constants';
->>>>>>> moved some things around to handle alternate mining origination points
 
 class GameManager extends EventEmitter implements AbstractGameManager {
   private readonly account: EthAddress | null;
@@ -115,7 +112,7 @@ class GameManager extends EventEmitter implements AbstractGameManager {
     localStorageManager: LocalStorageManager,
     snarkHelper: SnarkHelper,
     homeCoords: WorldCoords | null,
-    useMockHash: boolean,
+    useMockHash: boolean
   ) {
     super();
 
@@ -383,8 +380,7 @@ class GameManager extends EventEmitter implements AbstractGameManager {
       myPattern,
       this.worldRadius,
       this.planetRarity,
-      this.useMockHash,
-      CORES_TO_USE
+      this.useMockHash
     );
 
     this.minerManager.on(

--- a/src/api/GameManager.ts
+++ b/src/api/GameManager.ts
@@ -17,7 +17,11 @@ import {
   SpaceType,
 } from '../_types/global/GlobalTypes';
 import LocalStorageManager from './LocalStorageManager';
-import { MIN_CHUNK_SIZE } from '../utils/constants';
+import {
+  LOCATION_ID_UB,
+  MAX_CHUNK_SIZE,
+  DERIVED_CHUNK_SIZE
+} from '../utils/constants';
 import mimcHash from '../miner/mimc';
 import ContractsAPI from './ContractsAPI';
 import MinerManager, {
@@ -59,10 +63,14 @@ export enum GameManagerEvent {
 }
 import TerminalEmitter, { TerminalTextStyle } from '../utils/TerminalEmitter';
 import { getAllTwitters, verifyTwitterHandle } from './UtilityServerAPI';
+<<<<<<< HEAD
 import EthereumAccountManager from './EthereumAccountManager';
 import { getRandomActionId } from '../utils/Utils';
 import NotificationManager from '../utils/NotificationManager';
 import { deriveChunkSize, parseCoresInput } from '../utils/cores';
+=======
+import { CORES_TO_USE } from '../utils/constants';
+>>>>>>> moved some things around to handle alternate mining origination points
 
 class GameManager extends EventEmitter implements AbstractGameManager {
   private readonly account: EthAddress | null;
@@ -108,7 +116,6 @@ class GameManager extends EventEmitter implements AbstractGameManager {
     snarkHelper: SnarkHelper,
     homeCoords: WorldCoords | null,
     useMockHash: boolean,
-    cores: number
   ) {
     super();
 
@@ -133,7 +140,6 @@ class GameManager extends EventEmitter implements AbstractGameManager {
     this.localStorageManager = localStorageManager;
     this.snarkHelper = snarkHelper;
     this.useMockHash = useMockHash;
-    this.cores = cores;
 
     this.balanceInterval = setInterval(() => {
       if (this.account) {
@@ -177,7 +183,6 @@ class GameManager extends EventEmitter implements AbstractGameManager {
       account
     );
     const localStorageManager = await LocalStorageManager.create(account);
-    const cores = parseCoresInput(window.localStorage.getItem('CORES_TO_USE'));;
     const homeCoords = await localStorageManager.getHomeCoords();
     const snarkHelper = SnarkHelper.create(useMockHash);
 
@@ -217,8 +222,7 @@ class GameManager extends EventEmitter implements AbstractGameManager {
       localStorageManager,
       snarkHelper,
       homeCoords,
-      useMockHash,
-      cores
+      useMockHash
     );
 
     // get twitter handles
@@ -371,7 +375,7 @@ class GameManager extends EventEmitter implements AbstractGameManager {
   private initMiningManager(homeCoords: WorldCoords): void {
     const myPattern: MiningPattern = new SpiralPattern(
       homeCoords,
-      this.useMockHash ? MAX_CHUNK_SIZE : deriveChunkSize(this.cores)
+      this.useMockHash ? MAX_CHUNK_SIZE : DERIVED_CHUNK_SIZE
     );
 
     this.minerManager = MinerManager.create(
@@ -380,7 +384,7 @@ class GameManager extends EventEmitter implements AbstractGameManager {
       this.worldRadius,
       this.planetRarity,
       this.useMockHash,
-      this.cores
+      CORES_TO_USE
     );
 
     this.minerManager.on(

--- a/src/api/GameManager.ts
+++ b/src/api/GameManager.ts
@@ -81,8 +81,7 @@ class GameManager extends EventEmitter implements AbstractGameManager {
   private readonly planetHelper: PlanetHelper;
 
   private readonly useMockHash: boolean;
-  private readonly cores: number;
-
+  
   private minerManager?: MinerManager;
   private hashRate: number;
 

--- a/src/api/GameManager.ts
+++ b/src/api/GameManager.ts
@@ -19,7 +19,6 @@ import {
 import LocalStorageManager from './LocalStorageManager';
 import {
   MAX_CHUNK_SIZE,
-  MIN_CHUNK_SIZE,
   DERIVED_CHUNK_SIZE
 } from '../utils/constants';
 import mimcHash from '../miner/mimc';
@@ -66,8 +65,6 @@ import { getAllTwitters, verifyTwitterHandle } from './UtilityServerAPI';
 import EthereumAccountManager from './EthereumAccountManager';
 import { getRandomActionId } from '../utils/Utils';
 import NotificationManager from '../utils/NotificationManager';
-import { deriveChunkSize, parseCoresInput } from '../utils/cores';
-import { CORES_TO_USE } from '../utils/constants';
 
 class GameManager extends EventEmitter implements AbstractGameManager {
   private readonly account: EthAddress | null;
@@ -645,7 +642,7 @@ class GameManager extends EventEmitter implements AbstractGameManager {
 
       const pattern: MiningPattern = new SpiralPattern(
         { x, y },
-        MIN_CHUNK_SIZE
+        DERIVED_CHUNK_SIZE
       );
       const chunkStore = new HomePlanetMinerChunkStore(perlinThreshold);
       const homePlanetFinder = MinerManager.create(
@@ -663,7 +660,7 @@ class GameManager extends EventEmitter implements AbstractGameManager {
           if (minedChunksCount % 8 === 0) {
             terminalEmitter.println(
               `Hashed ${
-                minedChunksCount * MIN_CHUNK_SIZE ** 2
+                minedChunksCount * DERIVED_CHUNK_SIZE ** 2
               } potential home planets...`
             );
           }

--- a/src/api/MinerManager.ts
+++ b/src/api/MinerManager.ts
@@ -10,7 +10,6 @@ import { MiningPattern } from '../utils/MiningPatterns';
 import perlin from '../miner/perlin';
 import { ChunkStore } from '../_types/darkforest/api/LocalStorageManagerTypes';
 import { getChunkKey } from '../utils/ChunkUtils';
-import { parseCoresInput } from '../utils/cores';
 import { CORES_TO_USE } from '../utils/constants';
 
 export enum MinerManagerEvent {
@@ -50,6 +49,7 @@ class MinerManager extends EventEmitter {
   private worldRadius: number;
   private readonly planetRarity: number;
   private cores = CORES_TO_USE;
+  // chunks we're exploring
   private exploringChunk: { [chunkKey: string]: ExploredChunkData } = {};
   // when we started exploring this chunk
   private exploringChunkStart: { [chunkKey: string]: number } = {};

--- a/src/api/MinerManager.ts
+++ b/src/api/MinerManager.ts
@@ -63,7 +63,6 @@ class MinerManager extends EventEmitter {
     worldRadius: number,
     planetRarity: number,
     useMockHash: boolean,
-    cores: number
   ) {
     super();
 
@@ -74,7 +73,6 @@ class MinerManager extends EventEmitter {
     // this.cores = navigator.hardwareConcurrency;
     this.workers = [];
     this.useMockHash = useMockHash;
-    this.cores = cores;
     if (useMockHash) {
       this.cores = 1;
     }
@@ -102,16 +100,14 @@ class MinerManager extends EventEmitter {
     miningPattern: MiningPattern,
     worldRadius: number,
     planetRarity: number,
-    useMockHash = false,
-    cores: number
+    useMockHash = false
   ): MinerManager {
     const minerManager = new MinerManager(
       chunkStore,
       miningPattern,
       worldRadius,
       planetRarity,
-      useMockHash,
-      cores
+      useMockHash
     );
     _.range(minerManager.cores).forEach((i) => minerManager.initWorker(i));
 

--- a/src/api/MinerManager.ts
+++ b/src/api/MinerManager.ts
@@ -62,7 +62,8 @@ class MinerManager extends EventEmitter {
     miningPattern: MiningPattern,
     worldRadius: number,
     planetRarity: number,
-    useMockHash: boolean
+    useMockHash: boolean,
+    cores: number
   ) {
     super();
 
@@ -73,8 +74,9 @@ class MinerManager extends EventEmitter {
     // this.cores = navigator.hardwareConcurrency;
     this.workers = [];
     this.useMockHash = useMockHash;
+    this.cores = cores;
     if (useMockHash) {
-      this.cores = parseCoresInput(window.localStorage.getItem('CORES_TO_USE'));
+      this.cores = 1;
     }
   }
 
@@ -100,14 +102,16 @@ class MinerManager extends EventEmitter {
     miningPattern: MiningPattern,
     worldRadius: number,
     planetRarity: number,
-    useMockHash = false
+    useMockHash = false,
+    cores: number
   ): MinerManager {
     const minerManager = new MinerManager(
       chunkStore,
       miningPattern,
       worldRadius,
       planetRarity,
-      useMockHash
+      useMockHash,
+      cores
     );
     _.range(minerManager.cores).forEach((i) => minerManager.initWorker(i));
 

--- a/src/api/MinerManager.ts
+++ b/src/api/MinerManager.ts
@@ -11,6 +11,7 @@ import perlin from '../miner/perlin';
 import { ChunkStore } from '../_types/darkforest/api/LocalStorageManagerTypes';
 import { getChunkKey } from '../utils/ChunkUtils';
 import { parseCoresInput } from '../utils/cores';
+import { CORES_TO_USE } from '../utils/constants';
 
 export enum MinerManagerEvent {
   DiscoveredNewChunk = 'DiscoveredNewChunk',
@@ -48,8 +49,7 @@ class MinerManager extends EventEmitter {
   private workers: Worker[];
   private worldRadius: number;
   private readonly planetRarity: number;
-  private cores = 1;
-  // chunks we're exploring
+  private cores = CORES_TO_USE;
   private exploringChunk: { [chunkKey: string]: ExploredChunkData } = {};
   // when we started exploring this chunk
   private exploringChunkStart: { [chunkKey: string]: number } = {};

--- a/src/api/MinerManager.ts
+++ b/src/api/MinerManager.ts
@@ -62,7 +62,7 @@ class MinerManager extends EventEmitter {
     miningPattern: MiningPattern,
     worldRadius: number,
     planetRarity: number,
-    useMockHash: boolean,
+    useMockHash: boolean
   ) {
     super();
 

--- a/src/api/MinerManager.ts
+++ b/src/api/MinerManager.ts
@@ -10,6 +10,7 @@ import { MiningPattern } from '../utils/MiningPatterns';
 import perlin from '../miner/perlin';
 import { ChunkStore } from '../_types/darkforest/api/LocalStorageManagerTypes';
 import { getChunkKey } from '../utils/ChunkUtils';
+import { parseCoresInput } from '../utils/cores';
 
 export enum MinerManagerEvent {
   DiscoveredNewChunk = 'DiscoveredNewChunk',
@@ -73,7 +74,7 @@ class MinerManager extends EventEmitter {
     this.workers = [];
     this.useMockHash = useMockHash;
     if (useMockHash) {
-      this.cores = 1;
+      this.cores = parseCoresInput(window.localStorage.getItem('CORES_TO_USE'));
     }
   }
 

--- a/src/app/GameWindowPanes/CoordsPane.tsx
+++ b/src/app/GameWindowPanes/CoordsPane.tsx
@@ -6,7 +6,7 @@ import perlin from '../../miner/perlin';
 import { SpaceType } from '../../_types/global/GlobalTypes';
 import GameUIManager from '../board/GameUIManager';
 import GameUIManagerContext from '../board/GameUIManagerContext';
-import { MIN_CHUNK_SIZE } from '../../utils/constants';
+import { DERIVED_CHUNK_SIZE } from '../../utils/constants';
 
 export function CoordsText() {
   const uiEmitter = UIEmitter.getInstance();
@@ -25,10 +25,10 @@ export function CoordsText() {
     if (uiManager) {
       const chunkLoc = {
         bottomLeft: {
-          x: Math.floor(vec.x / MIN_CHUNK_SIZE) * MIN_CHUNK_SIZE,
-          y: Math.floor(vec.y / MIN_CHUNK_SIZE) * MIN_CHUNK_SIZE,
+          x: Math.floor(vec.x / DERIVED_CHUNK_SIZE) * DERIVED_CHUNK_SIZE,
+          y: Math.floor(vec.y / DERIVED_CHUNK_SIZE) * DERIVED_CHUNK_SIZE,
         },
-        sideLength: MIN_CHUNK_SIZE,
+        sideLength: DERIVED_CHUNK_SIZE,
       };
       if (!uiManager.hasMinedChunk(chunkLoc)) return '???';
 

--- a/src/app/GameWindowPanes/ExploreContextPane.tsx
+++ b/src/app/GameWindowPanes/ExploreContextPane.tsx
@@ -11,10 +11,10 @@ import WindowManager, {
 } from '../../utils/WindowManager';
 import GameUIManager from '../board/GameUIManager';
 import GameUIManagerContext from '../board/GameUIManagerContext';
-import { MIN_CHUNK_SIZE } from '../../utils/constants';
 import { WorldCoords } from '../../utils/Coordinates';
 import { SpiralPattern } from '../../utils/MiningPatterns';
 import { TargetIcon, PauseIcon, PlayIcon } from '../Icons';
+import { DERIVED_CHUNK_SIZE } from '../../utils/constants';
 import { IconButton } from './ModalPane';
 import { TooltipTrigger } from './Tooltip';
 import TutorialManager, { TutorialState } from '../../utils/TutorialManager';
@@ -57,7 +57,7 @@ export function ExploreContextPane() {
     };
 
     const updatePattern = (worldCoords: WorldCoords) => {
-      const newpattern = new SpiralPattern(worldCoords, MIN_CHUNK_SIZE);
+      const newpattern = new SpiralPattern(worldCoords, DERIVED_CHUNK_SIZE);
       uiManager?.setMiningPattern(newpattern);
       setPattern(newpattern);
 

--- a/src/utils/MiningPatterns.ts
+++ b/src/utils/MiningPatterns.ts
@@ -30,6 +30,7 @@ export class SpiralPattern implements MiningPattern {
       sideLength: chunkSize,
     };
     this.chunkSideLength = chunkSize;
+    console.debug('[SpiralPattern]: Using chunk size ', chunkSize)
   }
 
   nextChunk(chunk: ChunkFootprint): ChunkFootprint {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,12 +1,16 @@
 import * as bigInt from 'big-integer';
+import { deriveChunkSize, parseCoresInput } from './cores';
 
 const MIN_CHUNK_SIZE = 16;
 const MAX_CHUNK_SIZE = 256;
 const LOCATION_ID_UB = bigInt(
   '21888242871839275222246405745257275088548364400416034343698204186575808495617'
 );
+const CORES_TO_USE = parseCoresInput(window.localStorage.getItem('CORES_TO_USE'))
 
-export { MIN_CHUNK_SIZE, MAX_CHUNK_SIZE, LOCATION_ID_UB };
+const DERIVED_CHUNK_SIZE = deriveChunkSize(CORES_TO_USE)
+
+export { MIN_CHUNK_SIZE, DERIVED_CHUNK_SIZE, MAX_CHUNK_SIZE, CORES_TO_USE, LOCATION_ID_UB };
 
 // no slash at end plz
 export const BLOCK_EXPLORER_URL = 'https://blockscout.com/poa/xdai';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -6,10 +6,10 @@ const MAX_CHUNK_SIZE = 256;
 const LOCATION_ID_UB = bigInt(
   '21888242871839275222246405745257275088548364400416034343698204186575808495617'
 );
-const CORES_TO_USE = parseCoresInput(window.localStorage.getItem('CORES_TO_USE'))
+const CORES_TO_USE = parseCoresInput(typeof window !== "undefined" ? window.localStorage.getItem('CORES_TO_USE') : 1)
 
 const DERIVED_CHUNK_SIZE = deriveChunkSize(CORES_TO_USE)
-
+console.debug('[CORES_TO_USE]: ', CORES_TO_USE, DERIVED_CHUNK_SIZE)
 export { MIN_CHUNK_SIZE, DERIVED_CHUNK_SIZE, MAX_CHUNK_SIZE, CORES_TO_USE, LOCATION_ID_UB };
 
 // no slash at end plz

--- a/src/utils/cores.ts
+++ b/src/utils/cores.ts
@@ -1,7 +1,12 @@
+import { MIN_CHUNK_SIZE, MAX_CHUNK_SIZE } from './constants'
+
 const DEFAULT_CORES = 1;
 
 const isValidCores = (cores: number) => 
   cores <= 16 && cores > 0
+
+export const deriveChunkSize = (cores: number) =>
+  Math.min(MAX_CHUNK_SIZE, cores * MIN_CHUNK_SIZE)
 
 export const parseCoresInput = (cores: any) => {
   if (!cores || cores === null) return DEFAULT_CORES;

--- a/src/utils/cores.ts
+++ b/src/utils/cores.ts
@@ -19,4 +19,4 @@ export const parseCoresInput = (cores: any) => {
     return cores;
   }
   return DEFAULT_CORES
-} 
+}

--- a/src/utils/cores.ts
+++ b/src/utils/cores.ts
@@ -5,8 +5,9 @@ const DEFAULT_CORES = 1;
 const isValidCores = (cores: number) => 
   cores <= 16 && cores > 0
 
+// ChunkSize is a measurement of length, not area
 export const deriveChunkSize = (cores: number) =>
-  Math.min(MAX_CHUNK_SIZE, cores * MIN_CHUNK_SIZE)
+  Math.max(Math.min(MAX_CHUNK_SIZE, Math.floor(Math.sqrt(MIN_CHUNK_SIZE * cores))), MIN_CHUNK_SIZE)
 
 export const parseCoresInput = (cores: any) => {
   if (!cores || cores === null) return DEFAULT_CORES;

--- a/src/utils/cores.ts
+++ b/src/utils/cores.ts
@@ -1,0 +1,17 @@
+const DEFAULT_CORES = 1;
+
+const isValidCores = (cores: number) => 
+  cores <= 16 && cores > 0
+
+export const parseCoresInput = (cores: any) => {
+  if (!cores || cores === null) return DEFAULT_CORES;
+
+  if (typeof(cores) === 'string') {
+    const intCores = parseInt(cores)
+    return isValidCores(intCores) ? intCores : DEFAULT_CORES
+  } else if (typeof(cores) === 'number') {
+    if (!isValidCores(cores)) return DEFAULT_CORES;
+    return cores;
+  }
+  return DEFAULT_CORES
+} 

--- a/src/utils/cores.ts
+++ b/src/utils/cores.ts
@@ -15,8 +15,7 @@ export const parseCoresInput = (cores: any) => {
     const intCores = parseInt(cores)
     return isValidCores(intCores) ? intCores : DEFAULT_CORES
   } else if (typeof(cores) === 'number') {
-    if (!isValidCores(cores)) return DEFAULT_CORES;
-    return cores;
+    return isValidCores(cores) ? cores : DEFAULT_CORES;
   }
   return DEFAULT_CORES
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1323,9 +1323,9 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-"blake2b-wasm@git+https://github.com/jbaylina/blake2b-wasm.git":
+"blake2b-wasm@https://github.com/jbaylina/blake2b-wasm.git":
   version "2.1.0"
-  resolved "git+https://github.com/jbaylina/blake2b-wasm.git#0d5f024b212429c7f50a7f533aa3a2406b5b42b3"
+  resolved "https://github.com/jbaylina/blake2b-wasm.git#0d5f024b212429c7f50a7f533aa3a2406b5b42b3"
   dependencies:
     nanoassert "^1.0.0"
 


### PR DESCRIPTION
### Description
Adds support for `CORES_TO_USE` local storage key value to control miner's access to cores. Scales up the chunk size by `MIN_CHUNK_SIZE` (16) for each core up to a max of `MAX_CHUNK_SIZE` (256).

### To use:
1) Navigate to the game's website, open your chrome/brave browser's dev tools (F12 hotkey) and navigate to the **Application** header of the opened side menu.
2) Click **Local Storage** inside the Storage menu. Then click on the url that corresponds to the game's website. A Key/Value table will appear
3) In the **Key** section of the table, type in `CORES_TO_USE`.
4) In the **Value** section of the table, type in the number of cores of your cpu you'd like to use for mining (between 1 and 16 - most CPUs have 2-8 cores but be sure to leave open some cores to allow your computer to continue functioning well).

This will make the miner use the number of cores specified for mining :3 