### PR TITLE
Snark Task queue refactor to prevent OOM bug

### DIFF
--- a/src/api/SnarkArgsHelper.ts
+++ b/src/api/SnarkArgsHelper.ts
@@ -3,19 +3,23 @@ import {
   ContractCallArgs,
   InitializePlayerArgs,
   MoveSnarkArgs,
-} from '../_types/darkforest/api/ContractsAPITypes';
+} from "../_types/darkforest/api/ContractsAPITypes";
 import {
   SnarkJSProof,
   SnarkJSProofAndSignals,
   SnarkLogData,
-} from '../_types/global/GlobalTypes';
-import { BigInteger } from 'big-integer';
-import mimcHash, { modPBigInt, modPBigIntNative } from '../miner/mimc';
-import * as bigInt from 'big-integer';
-import { fakeHash } from '../miner/permutation';
-import TerminalEmitter, { TerminalTextStyle } from '../utils/TerminalEmitter';
-import perlin from '../miner/perlin';
-import * as CRC32 from 'crc-32';
+} from "../_types/global/GlobalTypes";
+import { BigInteger } from "big-integer";
+import mimcHash, { modPBigInt, modPBigIntNative } from "../miner/mimc";
+import * as bigInt from "big-integer";
+import { fakeHash } from "../miner/permutation";
+import TerminalEmitter, { TerminalTextStyle } from "../utils/TerminalEmitter";
+import perlin from "../miner/perlin";
+import * as CRC32 from "crc-32";
+
+type ZKSnarkTaskId = {
+  id: number;
+};
 
 type InitInfo = {
   x: string;
@@ -38,7 +42,7 @@ type FindArtifactInfo = {
 };
 
 type SnarkJSBin = {
-  type: 'mem';
+  type: "mem";
   data: Uint8Array;
 };
 
@@ -59,15 +63,81 @@ type ZKPTask = {
  * if we have to write a third one then i'll abstract it
  */
 
+// * Needed to separate doProof from execute while still passing back a Promise associated with the task. 
+// To do this we're going to generate the promise to insert into the taskQueue as well as into the ZKSnarkPromiseCache
+// Instead of directly returning the promise we'll return the id that can be used to get the promise from the PromiseCache
+// We can than call executeBatch which copies the taskQueue, reset the queue's contents, and then "reduces" through chain.
+// The corresponding Promise in the cache will resolve when the task is completed in executeBatch
+// WeakMap will garbage collect the promises once there is no reference to them outside of the WeakMap which should prevent the map from growing too large
+
 class SnarkProverQueue {
   private taskQueue: ZKPTask[];
   private currentlyExecuting: boolean;
+  private nextBatchQueued: boolean;
+  private executionPromise: Promise<any>;
   private taskCount: number;
-
+  public ZKSnarkPromiseCache: WeakMap<ZKSnarkTaskId, Promise<any>>;
   constructor() {
     this.taskQueue = [];
     this.currentlyExecuting = false;
+    this.nextBatchQueued = false;
+    this.executionPromise = Promise.resolve();
     this.taskCount = 0;
+    this.ZKSnarkPromiseCache = new WeakMap();
+  }
+
+  public insertTask(
+    input: any,
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    circuit: string | SnarkJSBin,
+    zkey: string | SnarkJSBin
+  ): ZKSnarkTaskId {
+    const taskId = this.taskCount++;
+    const TasksPromise = new Promise<SnarkJSProofAndSignals>(
+      (resolve, reject) => {
+        this.taskQueue.push({
+          input,
+          circuit,
+          zkey,
+          taskId,
+          onSuccess: resolve,
+          onError: reject,
+        });
+      }
+    );
+    const t: ZKSnarkTaskId = { id: taskId };
+    this.ZKSnarkPromiseCache.set(t, TasksPromise);
+    this.executeBatch();
+    return t;
+  }
+
+  public async executeBatch() {
+    if (this.nextBatchQueued) {
+      //If the next batch is already queued prevent multiple empty batches from building up
+      return;
+    }
+    if (this.currentlyExecuting) {
+      this.nextBatchQueued = true;
+      await this.executionPromise;
+      //Will be unset after execution chain has resolved
+      this.currentlyExecuting = true;
+      this.nextBatchQueued = false;
+      //Executing this batch, next execute call should be 'nextBatch'
+    }
+    //Grab Batch and empty task queue
+    const batch = [...this.taskQueue];
+    this.taskQueue = [];
+    // Reducing here rather than recursing should prevent OOM
+    // We want grab the actual promise here not await it.
+    this.executionPromise = batch.reduce((chain, task) => {
+      return chain.then((_) => this.execute(task));
+    }, Promise.resolve());
+    // await the task chain to be finished.
+    await this.executionPromise;
+    // set currently executing to false so next batch can start
+    this.currentlyExecuting = false;
+    // retun this.exectionPromise so downstream can take async action on
+    return this.executionPromise;
   }
 
   public doProof(
@@ -106,22 +176,11 @@ class SnarkProverQueue {
       console.log(`proved ${task.taskId}`);
       task.onSuccess(res);
     } catch (e) {
-      console.error('error while calculating SNARK proof:');
+      console.error("error while calculating SNARK proof:");
       console.error(e);
       task.onError(e);
     }
     this.currentlyExecuting = false;
-    this.scheduleNext();
-  }
-
-  // so that the calling context variable don't stay in memory
-  private async scheduleNext() {
-    setTimeout(() => {
-      const next = this.taskQueue.shift();
-      if (next) {
-        this.execute(next);
-      }
-    }, 0);
   }
 }
 
@@ -153,7 +212,7 @@ class SnarkArgsHelper {
       const start = Date.now();
       const terminalEmitter = TerminalEmitter.getInstance();
       terminalEmitter.println(
-        'INIT: calculating witness and proof',
+        "INIT: calculating witness and proof",
         TerminalTextStyle.Sub
       );
       const input: InitInfo = {
@@ -168,10 +227,12 @@ class SnarkArgsHelper {
 
       const snarkProof: SnarkJSProofAndSignals = this.useMockHash
         ? SnarkArgsHelper.fakeProof()
-        : await this.snarkProverQueue.doProof(
-            input,
-            '/public/circuits/init/circuit.wasm?id=6',
-            '/public/init.zkey?id=5'
+        : await this.snarkProverQueue.ZKSnarkPromiseCache.get(
+            this.snarkProverQueue.insertTask(
+              input,
+              "/public/circuits/init/circuit.wasm?id=6",
+              "/public/init.zkey?id=5"
+            )
           );
       const ret = this.callArgsFromProofAndSignals(
         snarkProof.proof,
@@ -199,10 +260,9 @@ class SnarkArgsHelper {
   ): Promise<[MoveSnarkArgs, SnarkLogData]> {
     try {
       const terminalEmitter = TerminalEmitter.getInstance();
-
       const start = Date.now();
       terminalEmitter.println(
-        'MOVE: calculating witness and proof',
+        "MOVE: calculating witness and proof",
         TerminalTextStyle.Sub
       );
       const input: MoveInfo = {
@@ -213,27 +273,30 @@ class SnarkArgsHelper {
         r: r.toString(),
         distMax: distMax.toString(),
       };
-      const circuitRaw = await fetch('/public/circuits/move/circuit.wasm?id=5')
+      const circuitRaw = await fetch("/public/circuits/move/circuit.wasm?id=5")
         .then((res) => res.arrayBuffer())
         .then((ab) => new Uint8Array(ab));
-      const zkeyRaw = await fetch('/public/move.zkey?id=5')
+      const zkeyRaw = await fetch("/public/move.zkey?id=5")
         .then((res) => res.arrayBuffer())
         .then((ab) => new Uint8Array(ab));
-      const snarkjsRaw = await fetch('/public/snarkjs.min.js')
+      const snarkjsRaw = await fetch("/public/snarkjs.min.js")
         .then((res) => res.arrayBuffer())
         .then((ab) => new Uint8Array(ab));
       const circuitData: SnarkJSBin = {
-        type: 'mem',
+        type: "mem",
         data: circuitRaw,
       };
       const zkeyData: SnarkJSBin = {
-        type: 'mem',
+        type: "mem",
         data: zkeyRaw,
       };
 
       const snarkProof: SnarkJSProofAndSignals = this.useMockHash
         ? SnarkArgsHelper.fakeProof()
-        : await this.snarkProverQueue.doProof(input, circuitData, zkeyData);
+        : await this.snarkProverQueue.ZKSnarkPromiseCache.get(
+            this.snarkProverQueue.insertTask(input, circuitData, zkeyData)
+          );
+
       const hash1 = this.useMockHash ? fakeHash(x1, y1) : mimcHash(x1, y1);
       const hash2 = this.useMockHash ? fakeHash(x2, y2) : mimcHash(x2, y2);
       const perl2 = perlin({ x: x2, y: y2 });
@@ -253,13 +316,14 @@ class SnarkArgsHelper {
         snarkProof.proof,
         publicSignals.map((x) => modPBigIntNative(x))
       );
-      const vkey = await fetch('public/move_vkey.json').then((res) =>
+      const vkey = await fetch("public/move_vkey.json").then((res) =>
         res.json()
       );
       const localVerified = await window.snarkjs.groth16.verify(
         vkey,
         snarkProof.publicSignals,
-        snarkProof.proof
+        snarkProof.proof,
+        console
       );
       const snarkLogs: SnarkLogData = {
         expectedSignals: snarkProof.publicSignals,
@@ -281,7 +345,7 @@ class SnarkArgsHelper {
 
       const start = Date.now();
       terminalEmitter.println(
-        'ARTIFACT: calculating witness and proof',
+        "ARTIFACT: calculating witness and proof",
         TerminalTextStyle.Sub
       );
       const input: FindArtifactInfo = {
@@ -290,11 +354,14 @@ class SnarkArgsHelper {
       };
       const snarkProof: SnarkJSProofAndSignals = this.useMockHash
         ? SnarkArgsHelper.fakeProof()
-        : await this.snarkProverQueue.doProof(
-            input,
-            '/public/circuits/biomebase/circuit.wasm?id=5',
-            '/public/biomebase.zkey?id=5'
+        : await this.snarkProverQueue.ZKSnarkPromiseCache.get(
+            this.snarkProverQueue.insertTask(
+              input,
+              "/public/circuits/biomebase/circuit.wasm?id=5",
+              "/public/biomebase.zkey?id=5"
+            )
           );
+
       const hash = this.useMockHash ? fakeHash(x, y) : mimcHash(x, y);
       const biomebase = bigInt(perlin({ x, y }, true, true));
       const publicSignals: BigInteger[] = [hash, biomebase];
@@ -318,13 +385,13 @@ class SnarkArgsHelper {
   private static fakeProof(): SnarkJSProofAndSignals {
     return {
       proof: {
-        pi_a: ['0', '0', '0'],
+        pi_a: ["0", "0", "0"],
         pi_b: [
-          ['0', '0'],
-          ['0', '0'],
-          ['0', '0'],
+          ["0", "0"],
+          ["0", "0"],
+          ["0", "0"],
         ],
-        pi_c: ['0', '0', '0'],
+        pi_c: ["0", "0", "0"],
       },
       publicSignals: [],
     };


### PR DESCRIPTION
Needed to separate doProof from execute while still passing back a Promise associated with the task. 
 To do this we're going to generate the promise to insert into the task queue as well as into the ZKSnarkPromiseCache
 Instead of directly returning the promise we'll return the id that can be used to get the promise from the PromiseCache
 We can then call executeBatch which copies the task queue, reset the queue's contents, and then "reduces" through the chain.
 The corresponding Promise in the cache will resolve when the task is completed in executeBatch
The cache uses WeakMap, which will garbage collect the promises once there is no reference to the promise outside of the WeakMap.
