### PR TITLE
A Typo in Invasion Logic

### DIFF
--- a/src/Backend/GameLogic/GameManager.ts
+++ b/src/Backend/GameLogic/GameManager.ts
@@ -1811,8 +1811,8 @@ class GameManager extends EventEmitter {
         throw new Error("you can't invade destroyed planets");
       }
 
-      if (planet.capturer !== EMPTY_ADDRESS) {
-        throw new Error("you can't invade planets that have already been captured");
+      if (planet.invader !== EMPTY_ADDRESS) {
+        throw new Error("you can't invade planets that have already been invaded");
       }
 
       if (planet.owner !== this.account) {


### PR DESCRIPTION
The current behavior allows invaded planet in capture zone, and it is not desired.